### PR TITLE
Feat improvement verify in frontend

### DIFF
--- a/demo/oracle/package.json
+++ b/demo/oracle/package.json
@@ -21,7 +21,6 @@
     "lint": "npx eslint src/** --fix"
   },
   "dependencies": {
-    "@airstack/node": "^0.0.5",
     "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.0",
     "dotenv": "^16.3.1",
@@ -30,7 +29,8 @@
     "graphql-request": "^6.1.0",
     "koa": "^2.14.2",
     "koa-helmet": "^7.0.2",
-    "o1js": "^0.13.1"
+    "o1js": "^0.13.1",
+    "util": "^0.12.5"
   },
   "devDependencies": {
     "@packages/tsconfig": "workspace:*",

--- a/demo/oracle/package.json
+++ b/demo/oracle/package.json
@@ -21,6 +21,7 @@
     "lint": "npx eslint src/** --fix"
   },
   "dependencies": {
+    "@airstack/node": "^0.0.5",
     "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.0",
     "dotenv": "^16.3.1",

--- a/demo/oracle/src/airstack/index.ts
+++ b/demo/oracle/src/airstack/index.ts
@@ -11,21 +11,15 @@ import {
   BlockchainName,
 } from './types';
 import Mock from './mocked.js';
-import { config } from "dotenv";
-
-config();
-const AIRSTACK_API_KEY = process.env.AIRSTACK_API_KEY;
 import { AIRSTACK_ENDPOINT, defaultBlockchain } from './config.js';
+import { config } from "dotenv";
+config();
+
+const AIRSTACK_API_KEY = process.env["AIRSTACK_API_KEY"];
 
 if (!AIRSTACK_API_KEY) {
   throw new Error('Missing AIRSTACK_API_KEY');
 }
-
-const graphQLClient = new GraphQLClient(AIRSTACK_ENDPOINT, {
-  headers: {
-    Authorization: AIRSTACK_API_KEY,
-  },
-});
 
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -73,6 +67,14 @@ export async function getBalance(
   `;
 
   try {
+    if (!AIRSTACK_API_KEY) {
+      throw new Error('Missing AIRSTACK_API_KEY');
+    }
+    const graphQLClient = new GraphQLClient(AIRSTACK_ENDPOINT, {
+      headers: {
+        Authorization: AIRSTACK_API_KEY,
+      },
+    });
     const res = await graphQLClient.request<AirstackTokenBalance>(balanceQuery);
     return res.TokenBalances.TokenBalance[0].formattedAmount || 0;
   } catch (e) {

--- a/demo/oracle/src/airstack/types.ts
+++ b/demo/oracle/src/airstack/types.ts
@@ -1,7 +1,12 @@
 export type AirstackTokenBalance = {
-  TokenBalance: {
-    formattedAmount: number;
-  } | null;
+  TokenBalances: {
+    TokenBalance: Array<{
+      token: {
+        id: string;
+      };
+      formattedAmount: number;
+    }>;
+  };
 };
 
 export type AirstackPoapHolder = {

--- a/demo/oracle/src/app.ts
+++ b/demo/oracle/src/app.ts
@@ -19,9 +19,15 @@ import {
   verifyPoapHolder,
   verifyXMTPenabled,
 } from './endpoints.js';
-
+import { init } from "@airstack/node";
 import * as dotenv from 'dotenv';
+
 dotenv.config();
+if (!process.env.AIRSTACK_API_KEY) {
+  throw new Error('AIRSTACK_API_KEY not set');
+}
+
+init(process.env.AIRSTACK_API_KEY);
 
 /**
  * Returns a Koa application instance with middleware and routes configured.

--- a/demo/oracle/src/app.ts
+++ b/demo/oracle/src/app.ts
@@ -19,15 +19,10 @@ import {
   verifyPoapHolder,
   verifyXMTPenabled,
 } from './endpoints.js';
-import { init } from "@airstack/node";
+
 import * as dotenv from 'dotenv';
 
 dotenv.config();
-if (!process.env.AIRSTACK_API_KEY) {
-  throw new Error('AIRSTACK_API_KEY not set');
-}
-
-init(process.env.AIRSTACK_API_KEY);
 
 /**
  * Returns a Koa application instance with middleware and routes configured.

--- a/demo/oracle/src/endpoints.ts
+++ b/demo/oracle/src/endpoints.ts
@@ -1,4 +1,6 @@
 import { ParameterizedContext } from 'koa';
+import { fetchQuery } from '@airstack/node';
+
 import {
   getBalance,
   getNftSaleVolume,
@@ -9,6 +11,8 @@ import {
   isPoapHolder,
   isXMTPenabled,
 } from './airstack/index.js';
+
+
 
 export async function getUserBalance(ctx: ParameterizedContext) {
   try {

--- a/demo/oracle/src/endpoints.ts
+++ b/demo/oracle/src/endpoints.ts
@@ -1,5 +1,4 @@
 import { ParameterizedContext } from 'koa';
-import { fetchQuery } from '@airstack/node';
 
 import {
   getBalance,

--- a/demo/web/src/components/attest/attest.tsx
+++ b/demo/web/src/components/attest/attest.tsx
@@ -138,7 +138,7 @@ const Attest = () => {
             </button>
             <button
               onClick={() => {
-                window.location.href = `/verify?attestationNote=${attest.finalResult}`;
+                window.location.href = `/verify?note=${attest.finalResult}`;
               }}
               className="w-36 p-2 bg-indigo-500 text-white font-bold rounded hover:bg-indigo-700 transition duration-300"
             >

--- a/demo/web/src/components/attest/proof.tsx
+++ b/demo/web/src/components/attest/proof.tsx
@@ -93,13 +93,22 @@ const ProofStep = () => {
     ]).toString();
 
 
+    const argsForAttestationNoteEncoded = {
+      conditionType: attest.statement.condition.type,
+      targetValue: attest.statement.condition.targetValue,
+      value: attest.privateData.data.value,
+      request: attest.statement.request,
+      hashRoute: attest.privateData.data.hashRoute,
+      hashAttestation: hashAttestation
+    }
     const attestationHashBase64 = createAttestationNoteEncoded(
       attest.statement.condition.type,
       attest.statement.condition.targetValue,
       attest.privateData.data.value,
       attest.statement.request,
       attest.privateData.data.hashRoute,
-      hashAttestation
+      hashAttestation,
+      attest.minaWallet.address
     );
 
     attest.setDisplayText('Getting transaction JSON...');

--- a/demo/web/src/components/attest/select.tsx
+++ b/demo/web/src/components/attest/select.tsx
@@ -99,11 +99,10 @@ const SelectStep = () => {
       signature: attest.ethereumWallet.signature,
       args: statement.request.args,
     };
-
     try {
       const response = await axios.post(
         `${ORACLE_ENDPOINT}${statement.request.route}`,
-        request_data
+        request_data,
       );
 
       const body = response.data as SignResponse;

--- a/demo/web/src/types.ts
+++ b/demo/web/src/types.ts
@@ -210,3 +210,10 @@ export type AttestationNote = {
   hashRoute: string,
   sender: string,
 }
+
+export type ArgsHashAttestationCalculator = {
+  conditionType: string | number;
+  hashRoute: string;
+  targetValue: number;
+  sender: string;
+}

--- a/demo/web/src/types.ts
+++ b/demo/web/src/types.ts
@@ -208,4 +208,5 @@ export type AttestationNote = {
   targetValue: number,
   conditionType: string,
   hashRoute: string,
+  sender: string,
 }

--- a/demo/web/src/utils/calculateAttestationHash.ts
+++ b/demo/web/src/utils/calculateAttestationHash.ts
@@ -1,0 +1,36 @@
+import { Poseidon, Field, PublicKey } from "o1js";
+import {
+  ArgsHashAttestationCalculator,
+  Condition,
+} from "../types";
+
+export const calculateAttestationHash = (
+  argsAttestation: ArgsHashAttestationCalculator
+) => {
+  let conditionTypeNumber: number;
+  switch (argsAttestation.conditionType) {
+    case Condition.LESS_THAN:
+      conditionTypeNumber = 1;
+      break;
+    case Condition.GREATER_THAN:
+      conditionTypeNumber = 2;
+      break;
+    case Condition.EQUAL:
+      conditionTypeNumber = 3;
+      break;
+    case Condition.DIFFERENT:
+      conditionTypeNumber = 4;
+      break;
+    default:
+      throw new Error("conditionType not supported");
+  }
+
+  const hashAttestation = Poseidon.hash([
+    Field.from(argsAttestation.hashRoute),
+    Field.from(conditionTypeNumber),
+    Field.from(argsAttestation.targetValue),
+    PublicKey.fromBase58(argsAttestation.sender).toFields()[0],
+  ]).toString();
+
+  return hashAttestation;
+};

--- a/demo/web/src/utils/createBase64Attestation.ts
+++ b/demo/web/src/utils/createBase64Attestation.ts
@@ -1,4 +1,4 @@
-import { Condition, AttestationNote, OracleRequest } from "../types";
+import { Condition, AttestationNote, OracleRequest, OracleRoute } from "../types";
 
 const getConditionString = (condition: Condition) => {
   switch (condition) {
@@ -21,25 +21,28 @@ export const createAttestationNoteEncoded = (
   value: number,
   request: OracleRequest,
   hashRoute: string,
-  hashAttestation: string
+  hashAttestation: string,
+  sender: string
 ): string => {
   const operation = getConditionString(conditionType);
 
   // todo: we should put in the statement "I, ${Mina address}, ..." and use that addres to fetch events (faster) + better ux
   const attestation: AttestationNote = {
     attestationHash: hashAttestation,
-    statement: `I attest that my value is ${operation} ${targetValue} for ${
+    statement: `I, ${sender}, attest that my value is ${operation} ${targetValue} for ${
       request.route
     } with ${JSON.stringify(request.args)}.`,
     value: value,
     targetValue: targetValue,
     conditionType: conditionType,
     hashRoute: hashRoute,
+    sender: sender,
   };
 
   const jsonString = JSON.stringify(attestation);
   return Buffer.from(jsonString).toString("base64");
 };
+
 
 export const decodeAttestationNote = (
   base64Attestation: string
@@ -47,17 +50,36 @@ export const decodeAttestationNote = (
   const jsonString = Buffer.from(base64Attestation, "base64").toString("utf-8");
   const attestation = JSON.parse(jsonString);
 
-  // Throw error if the attestation is not valid (i.e wrong type with AttetationNote)
+  // Throw error if the attestation is not valid (i.e wrong type with AttestationNote)
   if (
     !Object.hasOwn(attestation, "attestationHash") ||
     !Object.hasOwn(attestation, "statement") ||
     !Object.hasOwn(attestation, "value") ||
     !Object.hasOwn(attestation, "targetValue") ||
     !Object.hasOwn(attestation, "conditionType") ||
-    !Object.hasOwn(attestation, "hashRoute")
+    !Object.hasOwn(attestation, "hashRoute") ||
+    !Object.hasOwn(attestation, "sender")
   ) {
     throw new Error("Invalid note");
   }
 
   return attestation as AttestationNote;
 };
+
+const fakeNote=createAttestationNoteEncoded(
+  Condition.GREATER_THAN,
+  1000,
+  9000,
+  {
+    route: OracleRoute.BALANCE,
+    args: {
+        token: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+        blockchain: "polygon"
+    }
+},
+  "24771613593952144968161186171837982514830394192519219838611160378286992541903",
+  "17613068260150588986788240600449359622364004875948701399924500458447005281944",
+  'B62qm3bbCSy8ixuacL8FJzWdoj9MBjQGgrzHwiHtksBHTtmFWhidKxS'
+)
+
+console.log("my fake note is: ", fakeNote)

--- a/demo/web/src/utils/createBase64Attestation.ts
+++ b/demo/web/src/utils/createBase64Attestation.ts
@@ -1,4 +1,4 @@
-import { Condition, AttestationNote, OracleRequest, OracleRoute } from "../types";
+import { Condition, AttestationNote, OracleRequest } from "../types";
 
 const getConditionString = (condition: Condition) => {
   switch (condition) {
@@ -65,21 +65,3 @@ export const decodeAttestationNote = (
 
   return attestation as AttestationNote;
 };
-
-const fakeNote=createAttestationNoteEncoded(
-  Condition.GREATER_THAN,
-  1000,
-  9000,
-  {
-    route: OracleRoute.BALANCE,
-    args: {
-        token: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
-        blockchain: "polygon"
-    }
-},
-  "24771613593952144968161186171837982514830394192519219838611160378286992541903",
-  "17613068260150588986788240600449359622364004875948701399924500458447005281944",
-  'B62qm3bbCSy8ixuacL8FJzWdoj9MBjQGgrzHwiHtksBHTtmFWhidKxS'
-)
-
-console.log("my fake note is: ", fakeNote)

--- a/demo/web/src/utils/createFakeBase64Attestation.ts
+++ b/demo/web/src/utils/createFakeBase64Attestation.ts
@@ -1,0 +1,20 @@
+import { Condition, OracleRoute } from "../types"
+import { createAttestationNoteEncoded } from "./createBase64Attestation"
+
+const fakeNote=createAttestationNoteEncoded(
+    Condition.GREATER_THAN,
+    1000,
+    9000,
+    {
+      route: OracleRoute.BALANCE,
+      args: {
+          token: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+          blockchain: "polygon"
+      }
+  },
+    "24771613593952144968161186171837982514830394192519219838611160378286992541903",
+    "17613068260150588986788240600449359622364004875948701399924500458447005281944",
+    'B62qm3bbCSy8ixuacL8FJzWdoj9MBjQGgrzHwiHtksBHTtmFWhidKxS'
+  )
+  
+  console.log("My fake note is: ", fakeNote)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
 
   demo/oracle:
     dependencies:
-      '@airstack/node':
-        specifier: ^0.0.5
-        version: 0.0.5
       '@koa/cors':
         specifier: ^4.0.0
         version: 4.0.0
@@ -71,6 +68,9 @@ importers:
       o1js:
         specifier: ^0.13.1
         version: 0.13.1
+      util:
+        specifier: ^0.12.5
+        version: 0.12.5
     devDependencies:
       '@packages/tsconfig':
         specifier: workspace:*
@@ -239,14 +239,6 @@ packages:
 
   /@adraffy/ens-normalize@1.9.2:
     resolution: {integrity: sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==}
-    dev: false
-
-  /@airstack/node@0.0.5:
-    resolution: {integrity: sha512-bvRE2AaIxLPB4oX3VJe8lA1kXVGNuYt9T9KJngOxxx+6E7zxne5FDMjB//ngTvxm+UqCmAF3rkoVJXx/HN0ExQ==}
-    engines: {node: '>=14.17.0'}
-    dependencies:
-      '@types/node': 14.14.30
-      graphql: 16.7.1
     dev: false
 
   /@ampproject/remapping@2.2.1:
@@ -2645,10 +2637,6 @@ packages:
 
   /@types/ms@0.7.33:
     resolution: {integrity: sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==}
-    dev: false
-
-  /@types/node@14.14.30:
-    resolution: {integrity: sha512-gUWhy8s45fQp4PqqKecsnOkdW0kt1IaKjgOIR3HPokkzTmQj9ji2wWFID5THu1MKrtO+d4s2lVrlEhXUsPXSvg==}
     dev: false
 
   /@types/node@18.11.10:
@@ -5648,6 +5636,14 @@ packages:
     dependencies:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
+    dev: false
+
+  /is-arguments@1.1.1:
+    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      has-tostringtag: 1.0.0
     dev: false
 
   /is-array-buffer@3.0.2:
@@ -9331,6 +9327,16 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
+
+  /util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.1.1
+      is-generator-function: 1.0.10
+      is-typed-array: 1.1.12
+      which-typed-array: 1.1.11
+    dev: false
 
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -41,6 +41,9 @@ importers:
 
   demo/oracle:
     dependencies:
+      '@airstack/node':
+        specifier: ^0.0.5
+        version: 0.0.5
       '@koa/cors':
         specifier: ^4.0.0
         version: 4.0.0
@@ -236,6 +239,14 @@ packages:
 
   /@adraffy/ens-normalize@1.9.2:
     resolution: {integrity: sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==}
+    dev: false
+
+  /@airstack/node@0.0.5:
+    resolution: {integrity: sha512-bvRE2AaIxLPB4oX3VJe8lA1kXVGNuYt9T9KJngOxxx+6E7zxne5FDMjB//ngTvxm+UqCmAF3rkoVJXx/HN0ExQ==}
+    engines: {node: '>=14.17.0'}
+    dependencies:
+      '@types/node': 14.14.30
+      graphql: 16.7.1
     dev: false
 
   /@ampproject/remapping@2.2.1:
@@ -1814,7 +1825,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -1835,7 +1846,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -1872,7 +1883,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       jest-mock: 27.5.1
     dev: true
 
@@ -1882,7 +1893,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -1911,7 +1922,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -1995,7 +2006,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       '@types/yargs': 16.0.5
       chalk: 4.1.2
     dev: true
@@ -2425,7 +2436,7 @@ packages:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
     dev: true
 
   /@types/co-body@6.1.3:
@@ -2438,7 +2449,7 @@ packages:
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
     dev: true
 
   /@types/content-disposition@0.5.8:
@@ -2487,7 +2498,7 @@ packages:
   /@types/express-serve-static-core@4.17.41:
     resolution: {integrity: sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==}
     dependencies:
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       '@types/qs': 6.9.10
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -2511,7 +2522,7 @@ packages:
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
     dev: true
 
   /@types/hast@2.3.7:
@@ -2636,6 +2647,10 @@ packages:
     resolution: {integrity: sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==}
     dev: false
 
+  /@types/node@14.14.30:
+    resolution: {integrity: sha512-gUWhy8s45fQp4PqqKecsnOkdW0kt1IaKjgOIR3HPokkzTmQj9ji2wWFID5THu1MKrtO+d4s2lVrlEhXUsPXSvg==}
+    dev: false
+
   /@types/node@18.11.10:
     resolution: {integrity: sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==}
     dev: true
@@ -2646,7 +2661,6 @@ packages:
 
   /@types/node@18.15.13:
     resolution: {integrity: sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==}
-    dev: false
 
   /@types/node@20.4.1:
     resolution: {integrity: sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==}
@@ -2690,7 +2704,7 @@ packages:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
     dev: true
 
   /@types/serve-static@1.15.5:
@@ -2698,7 +2712,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.4
       '@types/mime': 3.0.4
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
     dev: true
 
   /@types/stack-utils@2.0.1:
@@ -5941,7 +5955,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -6066,7 +6080,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -6084,7 +6098,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -6100,7 +6114,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.6
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -6122,7 +6136,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -6177,7 +6191,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
     dev: true
 
   /jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
@@ -6233,7 +6247,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -6290,7 +6304,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       graceful-fs: 4.2.11
     dev: true
 
@@ -6329,7 +6343,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -6354,7 +6368,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -6365,7 +6379,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.11.17
+      '@types/node': 18.15.13
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true


### PR DESCRIPTION
Before this PR, someone could do a dummy attestation (i.e: "I got less than 1000ETH), get the attestationHash and generate an base64 attestation note with an other statement. The verifier would only check if attestationHash exists on the blockchain, but not if the statement displayed thanks to the base64 note corresponds to that statement hash.